### PR TITLE
firestoreに対するクエリを変更

### DIFF
--- a/src/controllers/MemberController.ts
+++ b/src/controllers/MemberController.ts
@@ -1,11 +1,12 @@
 import insertMember from "../usecases/insertMember";
 import Member from "../entities/member";
-import getMembers from "../usecases/getMembers";
+import getAllMembers from "../usecases/getMembers";
+import { getMembersByField } from "../usecases/getMembers";
 import setDiscordId from "../usecases/setDiscordId";
 
-export async function getAllMembers() {
+export async function getMembers() {
   try {
-    const members = await getMembers();
+    const members = await getAllMembers();
     return members;
   } catch (error) {
     console.error("Error getting members:", error);
@@ -15,8 +16,8 @@ export async function getAllMembers() {
 // Emailでメンバーを取得する 見つからなければundefinedを返す
 export async function getMemberByEmail(email: string): Promise<Member | undefined> {
   try {
-    const members = await getMembers();
-    const member = members.find((m) => m.mail === email);
+    const members = await getMembersByField("mail", email);
+    const member = members[0];
     return member ? member : undefined;
   } catch (error) {
     console.error("Error getting member by email:", error);
@@ -25,8 +26,8 @@ export async function getMemberByEmail(email: string): Promise<Member | undefine
 
 export async function getMemberByDiscordId(discordId: string): Promise<Member | undefined> {
   try {
-    const members = await getMembers();
-    const member = members.find((m) => m.discordId === discordId);
+    const members = await getMembersByField("discordId", discordId);
+    const member = members[0];
     return member ? member : undefined;
   } catch (error) {
     console.error("Error getting member by discord id:", error);

--- a/src/usecases/getMembers.ts
+++ b/src/usecases/getMembers.ts
@@ -3,9 +3,10 @@ import Member from "../entities/member";
 import { db } from "../infra/firebase";
 
 const firestore = getFirestore();
+const collectionName = "members";
 
 async function getAllMembers(): Promise<Member[]> {
-  const snapshot = await db.collection("members").get();
+  const snapshot = await db.collection(collectionName).get();
   const members: Member[] = snapshot.docs.map((doc) =>
     convertToMember({
       id: doc.id,
@@ -16,7 +17,7 @@ async function getAllMembers(): Promise<Member[]> {
 }
 
 async function getMembersByField(fieldName: string, value: string): Promise<Member[]> {
-  const membersRef = collection(firestore, "members");
+  const membersRef = collection(firestore, collectionName);
   const q = query(membersRef, where(fieldName, "==", value));
   const querySnapshot = await getDocs(q);
   

--- a/src/usecases/getMembers.ts
+++ b/src/usecases/getMembers.ts
@@ -1,9 +1,26 @@
+import { getFirestore, collection, query, where, getDocs } from "firebase/firestore";
 import Member from "../entities/member";
 import { db } from "../infra/firebase";
 
-async function getMembers(): Promise<Member[]> {
+const firestore = getFirestore();
+
+async function getAllMembers(): Promise<Member[]> {
   const snapshot = await db.collection("members").get();
   const members: Member[] = snapshot.docs.map((doc) =>
+    convertToMember({
+      id: doc.id,
+      ...doc.data(),
+    })
+  );
+  return members;
+}
+
+async function getMembersByField(fieldName: string, value: string): Promise<Member[]> {
+  const membersRef = collection(firestore, "members");
+  const q = query(membersRef, where(fieldName, "==", value));
+  const querySnapshot = await getDocs(q);
+  
+  const members: Member[] = querySnapshot.docs.map((doc) =>
     convertToMember({
       id: doc.id,
       ...doc.data(),
@@ -23,4 +40,5 @@ function convertToMember(docData: FirebaseFirestore.DocumentData): Member {
   };
 }
 
-export default getMembers;
+export default getAllMembers;
+export { getMembersByField };

--- a/src/utils/authMember.ts
+++ b/src/utils/authMember.ts
@@ -1,9 +1,9 @@
 import Member from "../entities/member";
 import AuthData from "../types/authData";
-import getMembers from "../usecases/getMembers";
+import getAllMembers from "../usecases/getMembers";
 
 async function authMember(authData: AuthData): Promise<boolean> {
-  const members: Member[] = await getMembers();
+  const members: Member[] = await getAllMembers();
   //membersの中からauthDataと一致するものがあるかどうかを確認する
   const authMember: Member | undefined = members.find((member) => {
     return (


### PR DESCRIPTION
# やったこと
- firestoreからdocumentを引き出す際、毎回全てのドキュメントを引き出すようになっていたため、それを変更。
- 特定の属性でdocumentを探す際にはクエリを使うようになった。