### PR TITLE
feat:renallAllコマンドが失敗した人最大10人メンションするように

### DIFF
--- a/src/application/commands/implementations/renameAll.ts
+++ b/src/application/commands/implementations/renameAll.ts
@@ -1,4 +1,4 @@
-import { type CommandInteraction, SlashCommandBuilder } from "discord.js";
+import { type CommandInteraction, SlashCommandBuilder, type GuildMember } from "discord.js";
 import type Command from "../../../domain/types/command";
 import logger from "../../../infrastructure/logger";
 import { getMemberByDiscordIdController } from "../../controllers/MemberController";
@@ -29,6 +29,7 @@ async function renameALLHandler(interaction: CommandInteraction) {
   const members = await interaction.guild.members.fetch();
   let successCount = 0;
   let failureCount = 0;
+  const failedMembers: GuildMember[] = [];
   const renamePromises = members.map(async (member) => {
     try {
       const registeredMember = await getMemberByDiscordIdController(member.id);
@@ -42,14 +43,20 @@ async function renameALLHandler(interaction: CommandInteraction) {
     } catch (error) {
       // NOTE: ニックネーム変更に一人が失敗しても全体の処理を止めない
       failureCount++;
+      failedMembers.push(member);
       // NOTE: 例外に関しては全体の処理を止めずにログ出力する
       logger.error(`Failed to rename ${member}: ${error}`);
     }
   });
 
   await Promise.all(renamePromises);
+  const failedMembersMessage = failedMembers.length > 0
+    ? failedMembers.length >= 10
+      ? '\n※10人以上のメンバーの変更に失敗しました。詳細はログを確認してください。'
+      : `\n失敗したメンバー:\n${failedMembers.join('\n')}`
+    : '';
   await interaction.followUp(
-    `ニックネームの変更が完了しました。\n成功: ${successCount}件\n失敗: ${failureCount}件`,
+    `ニックネームの変更が完了しました。\n成功: ${successCount}件\n失敗: ${failureCount}件${failedMembersMessage}`,
   );
 }
 


### PR DESCRIPTION
- Track and report failed member nickname changes
- Add detailed error messaging for nickname rename failures
- Limit detailed failure reporting for large numbers of failures