### PR TITLE
hotfix: 未捕捉の例外と拒否のハンドリングを追加

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,14 @@ import logger from "./infrastructure/logger";
 
 dotenv.config();
 
+process.on("uncaughtException", (error) => {
+  logger.error("Uncaught Exception:", error);
+});
+
+process.on("unhandledRejection", (reason, promise) => {
+  logger.error("Unhandled Rejection at:", promise, "reason:", reason);
+});
+
 const client = new CustomClient();
 const token = process.env.TOKEN;
 const userStates = new Map<string, AuthData>();
@@ -34,5 +42,5 @@ async function main() {
 }
 
 main().catch((error) => {
-  logger.error("Error in main: %o", error);
+  logger.error("Error in main function during startup:", error);
 });


### PR DESCRIPTION
Why

イベントハンドラ起因のProcessで例外が発生したときにProcessが終了する

What

NodejsにおけるProcess単位のライフサイクルでuncaughtExceptionイベントに対する処理を追加して、exitされることを防ぐ

Processに関するドキュメント
https://arc.net/l/quote/vhpdqsft

ちゃっぴーとの対話(結構面白い)
https://chatgpt.com/share/67f382d3-6d64-8012-92f3-45908b807583