### PR TITLE
hotfix: authCommandHandlerの応答処理を改善し、メンバー情報とメール認証のチェックを行う際に、応答を保留するメソッ…

### DIFF
--- a/src/application/commands/implementations/auth.ts
+++ b/src/application/commands/implementations/auth.ts
@@ -26,30 +26,30 @@ const authCommand: Command = {
 };
 
 async function authCommandHandler(interaction: CommandInteraction) {
-  //DMでは実行できないようにする
   if (!interaction.guild) {
     await interaction.reply("このコマンドはサーバーでのみ実行可能です");
     return;
   }
 
-  // Firestoreからメンバー情報を取得
-  const member = await getMemberByDiscordIdController(interaction.user.id);
-  if (!member) {
-    await interaction.reply("メンバー情報が見つかりませんでした");
-    return;
-  }
+  await interaction.deferReply();
 
-  // メール認証が完了しているか確認
-  const user: UserRecord = await adminAuth.getUserByEmail(member.mail);
-  if (!user.emailVerified) {
-    await interaction.reply("メール認証が完了していません");
-    return;
-  }
   try {
+    const member = await getMemberByDiscordIdController(interaction.user.id);
+    if (!member) {
+      await interaction.editReply("メンバー情報が見つかりませんでした");
+      return;
+    }
+
+    const user: UserRecord = await adminAuth.getUserByEmail(member.mail);
+    if (!user.emailVerified) {
+      await interaction.editReply("メール認証が完了していません");
+      return;
+    }
+
     await changeNickName(interaction, member);
     await giveRoles(interaction, member);
   } catch (error) {
-    await interaction.reply("認証に失敗しました");
+    await interaction.editReply("認証に失敗しました");
     throw error;
   }
 }
@@ -71,15 +71,11 @@ async function giveRoles(interaction: CommandInteraction, member: Member) {
     throw new Error("This command can only be used in a guild.");
   }
   const guildMember = await guild.members.fetch(interaction.user.id);
-  await giveAuthorizedRole(interaction, guild, guildMember);
+  await giveAuthorizedRole(guild, guildMember);
   await giveDepartmentRole(interaction, user, guildMember);
 }
 
-async function giveAuthorizedRole(
-  interaction: CommandInteraction,
-  guild: Guild,
-  guildMember: GuildMember,
-) {
+async function giveAuthorizedRole(guild: Guild, guildMember: GuildMember) {
   const authorizedRole: Role = await createRoleIfNotFound({
     guild,
     role: roleRegistry.getRole(roleRegistryKeys.authorizedRoleKey),
@@ -91,8 +87,6 @@ async function giveAuthorizedRole(
 
   await guildMember.roles.add(authorizedRole);
   await guildMember.roles.remove(unAuthorizedRole);
-
-  await interaction.reply("認証しました!");
 }
 
 async function giveDepartmentRole(


### PR DESCRIPTION
…ドを使用するように変更しました。これにより、3秒以内の返信チェックが不要になりました。