### PR TITLE
hotfix: scheduledMessages.tsの修正 - テストメッセージ削除とHot channelsスケジュール変更

### DIFF
--- a/src/config/scheduledMessages.ts
+++ b/src/config/scheduledMessages.ts
@@ -24,18 +24,8 @@ export const SCHEDULED_MESSAGE_CONFIGS: Array<
       const channelActivities = await getHotChannels(guildId);
       return createHotChannelsEmbed(guildId, channelActivities);
     },
-    // 午後四時
-    cronSchedule: "21 16 * * *",
-  },
-  {
-    id: "test",
-    description: "テスト",
-    channelId: config.generalChannelId,
-    messageContent: async () => {
-      const test: string = "String関数テスト";
-      return test;
-    },
-    cronSchedule: "25 16 * * *",
+    // 深夜0時
+    cronSchedule: "0 0 * * *",
   },
   {
     id: "garbage-collection-reminder",


### PR DESCRIPTION
## 概要
scheduledMessages.tsファイルの不要なテストメッセージを削除し、Hot channelsの実行スケジュールを適切な時間に修正しました。

## 変更内容
- ✅ テストメッセージ（id: "test"）を削除
- ✅ Hot channelsの実行時間を午後4時21分から深夜0時に変更（cronSchedule: "0 0 * * *"）

## 修正理由
- テストメッセージが本番環境で不要だったため
- Hot channelsは毎日の総集編として深夜0時に実行するのが適切なため

## テスト
- [x] ファイルの構文チェック完了
- [x] 削除対象のテストメッセージが正しく除外されていることを確認

## 変更されたファイル
- `src/config/scheduledMessages.ts`