### PR TITLE
fix: whoコマンドをAdminCommandに変更

### DIFF
--- a/src/config/scheduledMessages.ts
+++ b/src/config/scheduledMessages.ts
@@ -40,7 +40,7 @@ export const SCHEDULED_MESSAGE_CONFIGS: Array<
     channelId: config.generalChannelId,
     messageContent: "月末が近いです。月次報告は出しましたか？",
     cronSchedule: "0 12 28 * *", // 毎月28日
-  }, 
+  },
   {
     id: "monthly-report-reminder",
     description: "月次報告のリマインダー",

--- a/src/interfaces/discordjs/commands/implementations/who.ts
+++ b/src/interfaces/discordjs/commands/implementations/who.ts
@@ -7,7 +7,6 @@ import { itsCoreService } from "../../../../application/services/itsCoreService"
 import type AdminCommand from "../../../../domain/types/adminCommand";
 import { AdminRoleSpecification } from "../../../../infrastructure/authorization/adminRoleSpecification";
 
-
 const whoCommand: AdminCommand = {
   data: new SlashCommandBuilder()
     .setName("who")


### PR DESCRIPTION
who コマンドを誰でも打てるのは良くないと七草君が言っていました。

who command を、AdminCommand に追加し、認証の行（？）を追加した。

close #133 