### PR TITLE
fix: GatewayIntentBits.Guilds を追加しギルドキャッシュを有効化

### DIFF
--- a/src/domain/types/customClient.ts
+++ b/src/domain/types/customClient.ts
@@ -8,6 +8,7 @@ export class CustomClient extends Client {
   constructor() {
     super({
       intents: [
+        GatewayIntentBits.Guilds,
         GatewayIntentBits.DirectMessages,
         GatewayIntentBits.GuildMembers,
         GatewayIntentBits.GuildMessages,


### PR DESCRIPTION
## Summary
- `CustomClient` の intents に `GatewayIntentBits.Guilds` が含まれておらず、ギルド関連のキャッシュ（ロール等）が取得できなかった

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/its-discord/pull/164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
