### PR TITLE
fix: エラーログでスタックトレースが出力されるよう修正

### DIFF
--- a/src/application/usecases/updateMemberNickname.ts
+++ b/src/application/usecases/updateMemberNickname.ts
@@ -46,7 +46,7 @@ export async function updateMemberNickname(
         `ITSCore nickname updated for ${member.name} (${discordUserId}): ${newNickname}`,
       );
     } catch (error) {
-      logger.error(`Failed to update nickname in ITSCore: ${error}`);
+      logger.error("Failed to update nickname in ITSCore:", error);
       return {
         success: false,
         message: "ITSCoreでニックネームの更新に失敗しました。",
@@ -69,7 +69,7 @@ export async function updateMemberNickname(
         `Discord nickname updated for ${member.name} (${discordUserId}): ${discordDisplayName}`,
       );
     } catch (error) {
-      logger.error(`Failed to update nickname in Discord: ${error}`);
+      logger.error("Failed to update nickname in Discord:", error);
       return {
         success: false,
         message: "Discordでニックネームの更新に失敗しました。",

--- a/src/interfaces/discordjs/events/interactionCreate.ts
+++ b/src/interfaces/discordjs/events/interactionCreate.ts
@@ -54,7 +54,8 @@ export function setupInteractionCreateHandler(client: CustomClient): void {
       }
     } catch (error) {
       logger.error(
-        `Command failed: ${interaction.commandName} | User: ${userId} | Guild: ${guildId} | Error: ${error}`,
+        `Command failed: ${interaction.commandName} | User: ${userId} | Guild: ${guildId}`,
+        error,
       );
 
       // TODO: Adminにメンション付きで通知する # https://github.com/su-its/its-discord/issues/83


### PR DESCRIPTION
## Summary
- `logger.error()` でテンプレートリテラルに `${error}` を埋め込むと winston の `errors({ stack: true })` が機能せずスタックトレースが出力されない
- error を第2引数として渡すよう3箇所を修正

### 修正箇所
- `src/interfaces/discordjs/events/interactionCreate.ts`
- `src/application/usecases/updateMemberNickname.ts` (2箇所)

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/its-discord/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
