### PR TITLE
fix: ロール初期化で GUILD_ID 環境変数を使用するよう修正

### DIFF
--- a/src/application/ports/discordGuildPort.ts
+++ b/src/application/ports/discordGuildPort.ts
@@ -6,11 +6,6 @@ import type Role from "../../domain/types/role";
  */
 export interface DiscordGuildPort {
   /**
-   * Botが参加している最初のギルドを取得する
-   */
-  getFirstGuild(): Promise<string>;
-
-  /**
    * 指定されたロールが存在することを確認し、なければ作成する
    */
   ensureRoleExists(guildId: string, role: Role): Promise<void>;

--- a/src/application/services/discordServerService.ts
+++ b/src/application/services/discordServerService.ts
@@ -150,10 +150,6 @@ export class DiscordServerService {
   }
 
   // Guild operations
-  async getFirstGuild(): Promise<string> {
-    return discordServerServiceContainer.getDiscordGuildPort().getFirstGuild();
-  }
-
   async ensureRoleExists(guildId: string, role: Role): Promise<void> {
     return discordServerServiceContainer
       .getDiscordGuildPort()

--- a/src/application/usecases/initializeGuildRoles.ts
+++ b/src/application/usecases/initializeGuildRoles.ts
@@ -28,7 +28,6 @@ export async function initializeGuildRoles(guildId: string): Promise<void> {
 
 /**
  * 設定された GUILD_ID に対してロール初期化を実行するUsecase
- * TODO: getFirstGuild() を使用している他の箇所（postHotChannels, scheduledMessages）も GUILD_ID ベースに変更する #160
  */
 export async function initializeAllGuildsRoles(guildId: string): Promise<void> {
   try {

--- a/src/application/usecases/initializeGuildRoles.ts
+++ b/src/application/usecases/initializeGuildRoles.ts
@@ -27,11 +27,11 @@ export async function initializeGuildRoles(guildId: string): Promise<void> {
 }
 
 /**
- * すべてのギルドでロール初期化を実行するUsecase
+ * 設定された GUILD_ID に対してロール初期化を実行するUsecase
+ * TODO: getFirstGuild() を使用している他の箇所（postHotChannels, scheduledMessages）も GUILD_ID ベースに変更する #160
  */
-export async function initializeAllGuildsRoles(): Promise<void> {
+export async function initializeAllGuildsRoles(guildId: string): Promise<void> {
   try {
-    const guildId = await discordServerService.getFirstGuild();
     await initializeGuildRoles(guildId);
   } catch (error) {
     logger.error("Failed to initialize guild roles:", error);

--- a/src/application/usecases/postHotChannels.ts
+++ b/src/application/usecases/postHotChannels.ts
@@ -2,8 +2,7 @@ import { discordServerService } from "../services/discordServerService";
 import { getHotChannels } from "./getHotChannels";
 
 // TODO: Usecaseからdiscord.jsの依存を排除する
-export async function postHotChannels(channelId: string): Promise<void> {
-  const guildId = await discordServerService.getFirstGuild();
+export async function postHotChannels(channelId: string, guildId: string): Promise<void> {
   const channelActivities = await getHotChannels(guildId);
 
   // アクティブなチャンネルのみフィルタリング・ソート

--- a/src/application/usecases/postHotChannels.ts
+++ b/src/application/usecases/postHotChannels.ts
@@ -2,7 +2,10 @@ import { discordServerService } from "../services/discordServerService";
 import { getHotChannels } from "./getHotChannels";
 
 // TODO: Usecaseからdiscord.jsの依存を排除する
-export async function postHotChannels(channelId: string, guildId: string): Promise<void> {
+export async function postHotChannels(
+  channelId: string,
+  guildId: string,
+): Promise<void> {
   const channelActivities = await getHotChannels(guildId);
 
   // アクティブなチャンネルのみフィルタリング・ソート

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -16,6 +16,7 @@ export interface AdapterConfig {
 export interface AppConfig {
   environment: Environment;
   discordToken: string;
+  guildId: string;
   hotChannelId: string;
   generalChannelId: string;
   authRedirectUrl: string;
@@ -71,12 +72,17 @@ function parseAdapterType(
 export function loadConfig(): AppConfig {
   const environment = (process.env.ENVIRONMENT ?? "production") as Environment;
   const discordToken = process.env.TOKEN;
+  const guildId = process.env.GUILD_ID;
   const hotChannelId = process.env.HOT_CHANNEL_ID;
   const generalChannelId = process.env.GENERAL_CHANNEL_ID;
   const authRedirectUrl = process.env.AUTH_REDIRECT_URL;
 
   if (!discordToken) {
     throw new Error("Missing required environment variable: TOKEN");
+  }
+
+  if (!guildId) {
+    throw new Error("Missing required environment variable: GUILD_ID");
   }
 
   if (!hotChannelId) {
@@ -96,6 +102,7 @@ export function loadConfig(): AppConfig {
   return {
     environment,
     discordToken,
+    guildId,
     hotChannelId,
     generalChannelId,
     authRedirectUrl,

--- a/src/config/scheduledMessages.ts
+++ b/src/config/scheduledMessages.ts
@@ -1,4 +1,3 @@
-import { discordServerService } from "../application/services/discordServerService";
 import { createHotChannelsEmbed } from "../application/usecases/createHotChannelsEmbed";
 import { getHotChannels } from "../application/usecases/getHotChannels";
 import type { ScheduledMessageCreate } from "../domain/entities/scheduledMessage";
@@ -20,9 +19,8 @@ export const SCHEDULED_MESSAGE_CONFIGS: Array<
     description: "毎日のホットチャンネル投稿",
     channelId: config.hotChannelId,
     messageContent: async () => {
-      const guildId = await discordServerService.getFirstGuild();
-      const channelActivities = await getHotChannels(guildId);
-      return createHotChannelsEmbed(guildId, channelActivities);
+      const channelActivities = await getHotChannels(config.guildId);
+      return createHotChannelsEmbed(config.guildId, channelActivities);
     },
     // 深夜0時
     cronSchedule: "0 0 * * *",

--- a/src/infrastructure/discordjs/discordServerAdapter.ts
+++ b/src/infrastructure/discordjs/discordServerAdapter.ts
@@ -170,13 +170,6 @@ export class DiscordServerAdapter
   }
 
   // DiscordGuildPort implementation
-  async getFirstGuild(): Promise<string> {
-    const guild = this.client.guilds.cache.first();
-    if (!guild) throw new Error("No guild found");
-
-    return guild.id;
-  }
-
   async ensureRoleExists(guildId: string, role: Role): Promise<void> {
     const guild = this.client.guilds.cache.get(guildId);
     if (!guild) throw new Error(`Guild not found: ${guildId}`);

--- a/src/interfaces/discordjs/commands/implementations/hotChannels.ts
+++ b/src/interfaces/discordjs/commands/implementations/hotChannels.ts
@@ -22,7 +22,7 @@ async function hotChannelsHandler(interaction: ChatInputCommandInteraction) {
   // interaction.channelIdを使用して現在のチャンネルに送信
   if (!interaction.channelId) throw new Error("Channel ID not found");
 
-  await postHotChannels(interaction.channelId);
+  await postHotChannels(interaction.channelId, interaction.guild.id);
   await interaction.reply({
     content: "ホットチャンネルランキングを投稿しました！",
     ephemeral: true,

--- a/src/interfaces/discordjs/events/clientReady.ts
+++ b/src/interfaces/discordjs/events/clientReady.ts
@@ -7,7 +7,10 @@ import logger from "../../../infrastructure/logger";
  * ClientReady イベント発生時のハンドラを設定する。
  * クライアントのログイン状態を確認し、各ギルドに対してロール初期化処理を実施する。
  */
-export function setupClientReadyHandler(client: CustomClient, guildId: string): void {
+export function setupClientReadyHandler(
+  client: CustomClient,
+  guildId: string,
+): void {
   client.once(Events.ClientReady, async () => {
     logger.info("Client ready");
 

--- a/src/interfaces/discordjs/events/clientReady.ts
+++ b/src/interfaces/discordjs/events/clientReady.ts
@@ -7,7 +7,7 @@ import logger from "../../../infrastructure/logger";
  * ClientReady イベント発生時のハンドラを設定する。
  * クライアントのログイン状態を確認し、各ギルドに対してロール初期化処理を実施する。
  */
-export function setupClientReadyHandler(client: CustomClient): void {
+export function setupClientReadyHandler(client: CustomClient, guildId: string): void {
   client.once(Events.ClientReady, async () => {
     logger.info("Client ready");
 
@@ -25,7 +25,7 @@ export function setupClientReadyHandler(client: CustomClient): void {
 
     // ロール初期化を実施
     try {
-      await initializeAllGuildsRoles();
+      await initializeAllGuildsRoles(guildId);
       logger.info("Guild roles initialization completed");
     } catch (error) {
       logger.error("Failed to initialize guild roles:", error);

--- a/src/interfaces/discordjs/events/eventHandler.ts
+++ b/src/interfaces/discordjs/events/eventHandler.ts
@@ -8,8 +8,9 @@ import { setupMessageCreate } from "./messageCreate";
 export function setupEventHandlers(
   client: CustomClient,
   userStates: Map<string, AuthData>,
+  guildId: string,
 ) {
-  setupClientReadyHandler(client);
+  setupClientReadyHandler(client, guildId);
   setupInteractionCreateHandler(client);
   setupGuildMemberAddHandler(client);
   setupMessageCreate(client, userStates);

--- a/src/main.local.ts
+++ b/src/main.local.ts
@@ -40,7 +40,7 @@ async function main() {
       logger.debug(`Loaded command: ${command.data.name}`);
     }
 
-    setupEventHandlers(client, userStates);
+    setupEventHandlers(client, userStates, config.guildId);
 
     await client.login(config.discordToken);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ async function main() {
     }
 
     // イベントハンドラを設定
-    setupEventHandlers(client, userStates);
+    setupEventHandlers(client, userStates, config.guildId);
 
     // クライアントをログイン
     await client.login(config.discordToken);


### PR DESCRIPTION
## Summary
- `getFirstGuild()` が `client.guilds.cache.first()` を返すため、ボットが複数ギルドに参加している場合に意図しないギルドで処理が実行されていた
- `AppConfig` に `guildId` を追加し、全ての `getFirstGuild()` 呼び出しを `GUILD_ID` 環境変数ベースに置換
- `getFirstGuild()` の定義を Port / Service / Adapter から削除

### 変更箇所
- `src/config/environment.ts` — `guildId` を `AppConfig` に追加
- `src/application/usecases/initializeGuildRoles.ts` — `guildId` を引数で受け取るよう変更
- `src/application/usecases/postHotChannels.ts` — `guildId` を引数で受け取るよう変更
- `src/config/scheduledMessages.ts` — `config.guildId` を直接使用
- `src/interfaces/discordjs/commands/implementations/hotChannels.ts` — `interaction.guild.id` を渡すよう変更
- `src/application/ports/discordGuildPort.ts` — `getFirstGuild()` 削除
- `src/application/services/discordServerService.ts` — `getFirstGuild()` 削除
- `src/infrastructure/discordjs/discordServerAdapter.ts` — `getFirstGuild()` 削除

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)