### PR TITLE
fix: isDMAllowed のロジック反転を修正

### DIFF
--- a/src/interfaces/discordjs/events/interactionCreate.ts
+++ b/src/interfaces/discordjs/events/interactionCreate.ts
@@ -41,7 +41,7 @@ export function setupInteractionCreateHandler(client: CustomClient): void {
     );
 
     try {
-      if (command.isDMAllowed && !interaction.guild) {
+      if (!command.isDMAllowed && !interaction.guild) {
         await interaction.reply("このコマンドはサーバー内でのみ使用可能です。");
         logger.info(
           `Command failed: ${interaction.commandName} | User: ${userId} | Guild: ${guildId}`,


### PR DESCRIPTION
Closes #168

## Summary
isDMAllowed の条件判定がロジック反転していました。コマンドが DM を許可しており、かつギルドのコンテキストがない場合にエラーを返すべきでしたが、逆の条件になっていました。

## Changes
- Line 44 in `src/interfaces/discordjs/events/interactionCreate.ts` の条件を修正
- `if (command.isDMAllowed && !interaction.guild)` → `if (!command.isDMAllowed && !interaction.guild)`

TypeScript type checking verified without errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/its-discord/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
