### PR TITLE
refactor: ITSCorePort をジェネリクス化し application 層から core 依存を除去

### DIFF
--- a/src/application/ports/itsCorePort.ts
+++ b/src/application/ports/itsCorePort.ts
@@ -1,16 +1,13 @@
-// TODO: Port が @shizuoka-its/core に直接依存している。Member リモデリング時に
-// domain 層の型として再定義し、adapter でマッピングする設計に移行を検討する
-import type { CompleteAffiliation } from "@shizuoka-its/core";
 import type Member from "../../domain/entities/member";
 
 /**
  * ITSCoreとの連携に必要な最小限のデータ型
  */
-export interface MemberRegistrationData {
+export interface MemberRegistrationData<TAffiliation = unknown> {
   email: string;
   name: string;
   studentId: string;
-  affiliation: CompleteAffiliation;
+  affiliation: TAffiliation;
 }
 
 export interface MemberConnectionData {
@@ -26,12 +23,15 @@ export interface MemberNicknameUpdateData {
 /**
  * ITSCoreへのアクセスを抽象化するPort（ヘキサゴナルアーキテクチャ）
  * Application層はこのインターフェースのみに依存し、Infrastructure層の詳細を知らない
+ *
+ * @typeParam TAffiliation registerMember で使用する所属データの型。
+ * adapter が具体型（CompleteAffiliation 等）をバインドする。
  */
-export interface ITSCorePort {
+export interface ITSCorePort<TAffiliation = unknown> {
   /**
    * 新しいメンバーを登録する
    */
-  registerMember(data: MemberRegistrationData): Promise<void>;
+  registerMember(data: MemberRegistrationData<TAffiliation>): Promise<void>;
 
   /**
    * DiscordIDでメンバーを取得する

--- a/src/application/services/itsCoreService.ts
+++ b/src/application/services/itsCoreService.ts
@@ -1,4 +1,4 @@
-import type { ITSCorePort } from "../ports/itsCorePort";
+import type { ITSCorePort, MemberRegistrationData } from "../ports/itsCorePort";
 
 /**
  * DIコンテナ - ITSCorePortの実装を注入するためのシングルトン
@@ -38,21 +38,19 @@ export class ITSCoreService {
     return itsCoreServiceContainer.getITSCorePort();
   }
 
-  async registerMember(
-    data: Parameters<ITSCorePort["registerMember"]>[0],
-  ): Promise<void> {
+  async registerMember(data: MemberRegistrationData): Promise<void> {
     return this.port.registerMember(data);
   }
 
   async getMemberByDiscordId(
     discordId: string,
-  ): Promise<ReturnType<ITSCorePort["getMemberByDiscordId"]>> {
+  ): ReturnType<ITSCorePort["getMemberByDiscordId"]> {
     return this.port.getMemberByDiscordId(discordId);
   }
 
   async getMemberByEmail(
     email: string,
-  ): Promise<ReturnType<ITSCorePort["getMemberByEmail"]>> {
+  ): ReturnType<ITSCorePort["getMemberByEmail"]> {
     return this.port.getMemberByEmail(email);
   }
 
@@ -62,7 +60,7 @@ export class ITSCoreService {
     return this.port.connectDiscordAccount(data);
   }
 
-  async getMemberList(): Promise<ReturnType<ITSCorePort["getMemberList"]>> {
+  async getMemberList(): ReturnType<ITSCorePort["getMemberList"]> {
     return this.port.getMemberList();
   }
 

--- a/src/infrastructure/itscore/itsCoreAdaptor.ts
+++ b/src/infrastructure/itscore/itsCoreAdaptor.ts
@@ -1,4 +1,7 @@
-import { createMemberService } from "@shizuoka-its/core";
+import {
+  type CompleteAffiliation,
+  createMemberService,
+} from "@shizuoka-its/core";
 import type {
   ITSCorePort,
   MemberConnectionData,
@@ -12,10 +15,12 @@ import { memberWithDiscordToInternal, toMember } from "./mapper";
  * ITSCoreのメンバー機能へのアクセスを提供するAdapter（ヘキサゴナルアーキテクチャ）
  * v3のMemberService facadeを使用
  */
-export class ITSCoreAdaptor implements ITSCorePort {
+export class ITSCoreAdaptor implements ITSCorePort<CompleteAffiliation> {
   private service = createMemberService();
 
-  async registerMember(data: MemberRegistrationData): Promise<void> {
+  async registerMember(
+    data: MemberRegistrationData<CompleteAffiliation>,
+  ): Promise<void> {
     await this.service.register({
       name: data.name,
       studentId: data.studentId,

--- a/src/interfaces/discordjs/commands/implementations/register.ts
+++ b/src/interfaces/discordjs/commands/implementations/register.ts
@@ -1,5 +1,3 @@
-// TODO: interface 層が @shizuoka-its/core に直接依存している。
-// application 層のサービスとして wrap するか、core をドメイン依存として許容するか検討する
 import {
   type CompleteAffiliation,
   getAffiliationSteps,


### PR DESCRIPTION
## Summary
- `ITSCorePort<TAffiliation>` にジェネリクスを導入
- `CompleteAffiliation` の具体型バインドを adapter 層（infrastructure）に移動
- application 層・domain 層から `@shizuoka-its/core` の import をゼロに

### 依存の整理

| 層 | core 依存 | 状態 |
|----|----------|------|
| domain | なし | ✅ |
| application | なし | ✅ (Port はジェネリクスで `unknown` デフォルト) |
| infrastructure | あり | ✅ (adapter の責務として正当) |
| interface | あり | ✅ (driving adapter として正当) |

### 変更ファイル
- `src/application/ports/itsCorePort.ts` — `ITSCorePort<TAffiliation>`, `MemberRegistrationData<TAffiliation>` に変更、core import 削除
- `src/application/services/itsCoreService.ts` — `Parameters`/`ReturnType` の型参照を整理
- `src/infrastructure/itscore/itsCoreAdaptor.ts` — `ITSCorePort<CompleteAffiliation>` を実装
- `src/interfaces/discordjs/commands/implementations/register.ts` — TODO コメント削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/its-discord/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
