### PR TITLE
fix: /who で学籍番号が [object Object] になる問題を修正

### DIFF
--- a/src/infrastructure/itscore/mapper.ts
+++ b/src/infrastructure/itscore/mapper.ts
@@ -48,7 +48,7 @@ export function toMember(
     id: member.id,
     name: member.name,
     universityEmail: member.email.getValue(),
-    studentId: String(member.studentId),
+    studentId: member.studentId.getValue(),
     affiliation: completeAffiliationToAffiliation(member.affiliation),
     discord,
   };


### PR DESCRIPTION
## Summary

`/who` コマンドで学籍番号が \`[object Object]\` と表示される問題を修正。

## Why

\`@shizuoka-its/core\` の \`getByDiscordId\` が返す \`Member\` エンティティの \`studentId\` は値オブジェクト (\`StudentId\`) で、\`String()\` ではプリミティブな値を取り出せない。email と同様に \`.getValue()\` を使う必要があった。

## Test plan

- [x] \`npx tsc --noEmit\` パス
- [ ] \`/who @ユーザー\` で学籍番号が正しく表示されることを確認
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/its-discord/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
