### PR TITLE
fix: pin Node image and simplify corepack setup in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-FROM node:latest
+FROM node:24-slim
 
-ENV YARN_VERSION=4.3.1
-ENV PRISMA_CLIENT_ENGINE_TYPE=binary
-ENV PRISMA_ENABLE_TRACING=false
-
-RUN corepack enable && corepack prepare yarn@${YARN_VERSION} --activate
+RUN corepack enable
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Why

`FROM node:latest` が指す Node イメージが更新され、corepack が同梱されないバージョンに進んだ結果、`docker build` が `corepack: not found` で失敗するようになった。`node:latest` は floating tag で非決定的なため、再現性のある固定タグに切り替える。

併せて、以前から抱えていた以下の潜在問題も同時に解消する:

- **uuid v13 (ESM-only) を CJS から require する経路**: its-discord は `tsconfig.json` の `module: "commonjs"` のもと ts-node で実行されており、`import { v4 } from "uuid"` は実行時に `require("uuid")` に変換される。`@shizuoka-its/core` の CJS ビルド側でも同様に `require("uuid")` が走る。Node 22.12 未満では `ERR_REQUIRE_ESM` で落ちるため、Node 22.12 以降（`require(esm)` がデフォルト有効）に固定する必要がある。
- **yarn バージョンの二重管理**: Dockerfile の `ENV YARN_VERSION=4.3.1` と `package.json` の `packageManager: yarn@4.9.1` がズレていた。corepack は `package.json` の `packageManager` を自動で読むので、Dockerfile 側での指定は不要。
- **未使用の Prisma 関連 ENV**: 本プロジェクトは drizzle-orm ベースの `@shizuoka-its/core` を利用しており Prisma は使っていない。

## What

- `FROM node:latest` → `FROM node:24-slim` に固定
- `ENV YARN_VERSION=4.3.1` を削除（`package.json` の `packageManager` に一本化）
- `corepack prepare yarn@${YARN_VERSION} --activate` を削除し `corepack enable` のみに簡素化
- 未使用の `PRISMA_CLIENT_ENGINE_TYPE` / `PRISMA_ENABLE_TRACING` ENV を削除

## Test plan

- [x] `docker build -t its-discord .` がローカルで成功することを確認
- [ ] `docker run --rm its-discord` でアプリが起動することを確認
- [ ] CI の Docker ビルドが通ることを確認

## Note

`tsconfig.json` が `module: "commonjs"` のままという中長期的な構造問題は本 PR では対応していない。Node 24 の `require(esm)` が緩衝材として吸収してくれているため当面は動作するが、いずれ its-discord 自体の ESM 化（`"type": "module"` + `module: "NodeNext"`）を検討する余地がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/its-discord/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
