### PR TITLE
ITSの開室状況をwebsocketで取得するコマンドを実装

### DIFF
--- a/src/interfaces/discordjs/commands/implementations/door.ts
+++ b/src/interfaces/discordjs/commands/implementations/door.ts
@@ -1,67 +1,84 @@
 import {
-    type ChatInputCommandInteraction,
-    SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  SlashCommandBuilder,
 } from "discord.js";
 import WebSocket from "ws";
 import type Command from "../../../../domain/types/command";
 
 const doorCommand: Command = {
-    data: new SlashCommandBuilder()
-        .setName("door")
-        .setDescription("ITSの開室状況を表示します") as SlashCommandBuilder,
-    execute: doorCommandHandler,
-    isDMAllowed: true,
+  data: new SlashCommandBuilder()
+    .setName("door")
+    .setDescription("ITSの開室状況を表示します") as SlashCommandBuilder,
+  execute: doorCommandHandler,
+  isDMAllowed: true,
 };
 
-async function doorCommandHandler(
-    interaction: ChatInputCommandInteraction,
-) {
-    await interaction.deferReply({ ephemeral: true });
+async function doorCommandHandler(interaction: ChatInputCommandInteraction) {
+  await interaction.deferReply({ ephemeral: true });
 
-    let statusText: string;
+  let statusText: string;
 
-    try {
-        statusText = await new Promise<string>((resolve, reject) => {
-            const ws = new WebSocket("wss://its-status.woody1227.com/");
-            let resolved = false;
+  try {
+    statusText = await new Promise<string>((resolve, reject) => {
+      const ws = new WebSocket("wss://its-status.woody1227.com/");
+      let resolved = false;
 
-            const timeout = setTimeout(() => {
-                if (resolved) return;
-                resolved = true;
-                ws.close();
-                reject(new Error("WebSocket timeout"));
-            }, 8000);
+      const timeout = setTimeout(() => {
+        if (resolved) return;
+        resolved = true;
+        ws.close();
+        reject(new Error("WebSocket timeout"));
+      }, 8000);
 
-            ws.onmessage = (event) => {
-                if (resolved) return;
-                resolved = true;
-                clearTimeout(timeout);
+      ws.onmessage = (event) => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
 
-                try {
-                    const raw = typeof event.data === "string" ? event.data : event.data.toString();
-                    const parsed = raw ? JSON.parse(raw) : null;
-                    const open = parsed?.open ?? parsed?.isOpen ?? (parsed?.status === "open" ? true : parsed?.status === "closed" ? false : undefined);
-                    const text = parsed?.message ?? parsed?.text ?? (open === true ? "🟢 開室中" : open === false ? "🔴 閉室中" : raw || "⚪ 不明");
-                    resolve(String(text));
-                } catch {
-                    resolve(typeof event.data === "string" ? event.data : "❌ 通信に失敗しました");
-                } finally {
-                    ws.close();
-                }
-            };
+        try {
+          const raw =
+            typeof event.data === "string" ? event.data : event.data.toString();
+          const parsed = raw ? JSON.parse(raw) : null;
+          const open =
+            parsed?.open ??
+            parsed?.isOpen ??
+            (parsed?.status === "open"
+              ? true
+              : parsed?.status === "closed"
+                ? false
+                : undefined);
+          const text =
+            parsed?.message ??
+            parsed?.text ??
+            (open === true
+              ? "🟢 開室中"
+              : open === false
+                ? "🔴 閉室中"
+                : raw || "⚪ 不明");
+          resolve(String(text));
+        } catch {
+          resolve(
+            typeof event.data === "string"
+              ? event.data
+              : "❌ 通信に失敗しました",
+          );
+        } finally {
+          ws.close();
+        }
+      };
 
-            ws.onerror = () => {
-                if (resolved) return;
-                resolved = true;
-                clearTimeout(timeout);
-                reject(new Error("WebSocket error"));
-            };
-        });
-    } catch {
-        statusText = "❌ 通信に失敗しました";
-    }
+      ws.onerror = () => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
+        reject(new Error("WebSocket error"));
+      };
+    });
+  } catch {
+    statusText = "❌ 通信に失敗しました";
+  }
 
-    await interaction.editReply(`現在の開室状況: ${statusText}`);
+  await interaction.editReply(`現在の開室状況: ${statusText}`);
 }
 
 export default doorCommand;

--- a/src/interfaces/discordjs/commands/implementations/door.ts
+++ b/src/interfaces/discordjs/commands/implementations/door.ts
@@ -1,0 +1,67 @@
+import {
+    type ChatInputCommandInteraction,
+    SlashCommandBuilder,
+} from "discord.js";
+import WebSocket from "ws";
+import type Command from "../../../../domain/types/command";
+
+const doorCommand: Command = {
+    data: new SlashCommandBuilder()
+        .setName("door")
+        .setDescription("ITSの開室状況を表示します") as SlashCommandBuilder,
+    execute: doorCommandHandler,
+    isDMAllowed: true,
+};
+
+async function doorCommandHandler(
+    interaction: ChatInputCommandInteraction,
+) {
+    await interaction.deferReply({ ephemeral: true });
+
+    let statusText: string;
+
+    try {
+        statusText = await new Promise<string>((resolve, reject) => {
+            const ws = new WebSocket("wss://its-status.woody1227.com/");
+            let resolved = false;
+
+            const timeout = setTimeout(() => {
+                if (resolved) return;
+                resolved = true;
+                ws.close();
+                reject(new Error("WebSocket timeout"));
+            }, 8000);
+
+            ws.onmessage = (event) => {
+                if (resolved) return;
+                resolved = true;
+                clearTimeout(timeout);
+
+                try {
+                    const raw = typeof event.data === "string" ? event.data : event.data.toString();
+                    const parsed = raw ? JSON.parse(raw) : null;
+                    const open = parsed?.open ?? parsed?.isOpen ?? (parsed?.status === "open" ? true : parsed?.status === "closed" ? false : undefined);
+                    const text = parsed?.message ?? parsed?.text ?? (open === true ? "🟢 開室中" : open === false ? "🔴 閉室中" : raw || "⚪ 不明");
+                    resolve(String(text));
+                } catch {
+                    resolve(typeof event.data === "string" ? event.data : "❌ 通信に失敗しました");
+                } finally {
+                    ws.close();
+                }
+            };
+
+            ws.onerror = () => {
+                if (resolved) return;
+                resolved = true;
+                clearTimeout(timeout);
+                reject(new Error("WebSocket error"));
+            };
+        });
+    } catch {
+        statusText = "❌ 通信に失敗しました";
+    }
+
+    await interaction.editReply(`現在の開室状況: ${statusText}`);
+}
+
+export default doorCommand;

--- a/src/interfaces/discordjs/commands/index.ts
+++ b/src/interfaces/discordjs/commands/index.ts
@@ -9,6 +9,7 @@ import refreshRoles from "./implementations/refreshRoles";
 import register from "./implementations/register";
 import renameAll from "./implementations/renameAll";
 import who from "./implementations/who";
+import door from "./implementations/door";
 
 const registry = new CommandRegistry();
 
@@ -22,5 +23,6 @@ registry.register(refreshRoles);
 registry.register(register);
 registry.register(renameAll);
 registry.register(who);
+registry.register(door);
 
 export default registry;

--- a/src/interfaces/discordjs/commands/index.ts
+++ b/src/interfaces/discordjs/commands/index.ts
@@ -1,5 +1,6 @@
 import CommandRegistry from "./core/commandRegistry";
 import auth from "./implementations/auth";
+import door from "./implementations/door";
 import healthCheck from "./implementations/healthCheck";
 import hotChannels from "./implementations/hotChannels";
 import kill from "./implementations/kill";
@@ -9,7 +10,6 @@ import refreshRoles from "./implementations/refreshRoles";
 import register from "./implementations/register";
 import renameAll from "./implementations/renameAll";
 import who from "./implementations/who";
-import door from "./implementations/door";
 
 const registry = new CommandRegistry();
 


### PR DESCRIPTION
Discord BOTの管理サーバーを室内に移動するまでの暫定的な実装
websocketを用いてswitchbotから開室状況を取得して表示する
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/its-discord/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
