### PR TITLE
refactor: use case から interfaces 層への逆依存を CronSchedulerPort で解消

### DIFF
--- a/src/application/ports/cronSchedulerPort.ts
+++ b/src/application/ports/cronSchedulerPort.ts
@@ -1,0 +1,7 @@
+/**
+ * Cronジョブのスケジューリングを抽象化するPort
+ */
+export interface CronSchedulerPort {
+  scheduleJob(id: string, cronSchedule: string): void;
+  cancelJob(id: string): void;
+}

--- a/src/application/ports/deps.ts
+++ b/src/application/ports/deps.ts
@@ -1,3 +1,4 @@
+import type { CronSchedulerPort } from "./cronSchedulerPort";
 import type { DiscordChannelPort } from "./discordChannelPort";
 import type { DiscordGuildPort } from "./discordGuildPort";
 import type { DiscordMemberPort } from "./discordMemberPort";
@@ -18,4 +19,5 @@ export interface AppDeps {
   discordGuildPort: DiscordGuildPort;
   discordMessagePort: DiscordMessagePort;
   scheduledMessagePort: ScheduledMessagePort;
+  cronSchedulerPort: CronSchedulerPort;
 }

--- a/src/application/usecases/initializeScheduledMessagesFromConfig.ts
+++ b/src/application/usecases/initializeScheduledMessagesFromConfig.ts
@@ -1,6 +1,5 @@
 import { createScheduledMessageConfigs } from "../../config/scheduledMessages";
 import logger from "../../infrastructure/logger";
-import { addScheduledMessageJob } from "../../interfaces/cron/scheduledMessageCron";
 import type { AppDeps } from "../ports/deps";
 
 /**
@@ -55,8 +54,7 @@ export async function initializeScheduledMessagesFromConfig(
           },
         );
 
-        // Cronジョブを追加
-        addScheduledMessageJob(
+        deps.cronSchedulerPort.scheduleJob(
           scheduledMessage.id,
           scheduledMessage.cronSchedule,
         );

--- a/src/interfaces/cron/scheduledMessageCron.ts
+++ b/src/interfaces/cron/scheduledMessageCron.ts
@@ -1,4 +1,5 @@
 import { CronJob } from "cron";
+import type { CronSchedulerPort } from "../../application/ports/cronSchedulerPort";
 import type { AppDeps } from "../../application/ports/deps";
 import { sendScheduledMessage } from "../../application/usecases/sendScheduledMessage";
 import logger from "../../infrastructure/logger";
@@ -6,7 +7,7 @@ import logger from "../../infrastructure/logger";
 /**
  * アクティブなスケジュールメッセージのCronジョブを管理するクラス
  */
-class ScheduledMessageCronManager {
+class ScheduledMessageCronManager implements CronSchedulerPort {
   private jobs: Map<string, CronJob> = new Map();
   private deps: AppDeps | null = null;
 
@@ -15,6 +16,14 @@ class ScheduledMessageCronManager {
    */
   setDeps(deps: AppDeps): void {
     this.deps = deps;
+  }
+
+  scheduleJob(id: string, cronSchedule: string): void {
+    this.createJobForMessage(id, cronSchedule);
+  }
+
+  cancelJob(id: string): void {
+    this.stopJob(id);
   }
 
   /**
@@ -109,23 +118,3 @@ class ScheduledMessageCronManager {
 
 // シングルトンインスタンス
 export const scheduledMessageCronManager = new ScheduledMessageCronManager();
-
-/**
- * 新しいスケジュールメッセージのCronジョブを追加する
- * @param messageId メッセージID
- * @param cronSchedule Cron式
- */
-export function addScheduledMessageJob(
-  messageId: string,
-  cronSchedule: string,
-): void {
-  scheduledMessageCronManager.createJobForMessage(messageId, cronSchedule);
-}
-
-/**
- * スケジュールメッセージのCronジョブを削除する
- * @param messageId メッセージID
- */
-export function removeScheduledMessageJob(messageId: string): void {
-  scheduledMessageCronManager.stopJob(messageId);
-}

--- a/src/main.local.ts
+++ b/src/main.local.ts
@@ -73,6 +73,7 @@ async function main() {
       discordGuildPort: discordServerAdapter,
       discordMessagePort: discordServerAdapter,
       scheduledMessagePort: memoryScheduledMessageRepository,
+      cronSchedulerPort: scheduledMessageCronManager,
     };
 
     scheduledMessageCronManager.setDeps(deps);

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,9 +44,9 @@ async function main() {
       discordGuildPort: discordServerAdapter,
       discordMessagePort: discordServerAdapter,
       scheduledMessagePort: memoryScheduledMessageRepository,
+      cronSchedulerPort: scheduledMessageCronManager,
     };
 
-    // Cron manager に依存オブジェクトを設定
     scheduledMessageCronManager.setDeps(deps);
 
     // イベントハンドラを設定（ClientReady を捕捉するため login の前に登録する）


### PR DESCRIPTION
## Why

`initializeScheduledMessagesFromConfig`（use case）が `interfaces/cron/scheduledMessageCron` を直接 import しており、application → interfaces の逆依存が発生していた。

## What

- `CronSchedulerPort` を `application/ports/` に新設
- `ScheduledMessageCronManager` が `CronSchedulerPort` を実装
- use case は port 経由でジョブをスケジュールするように変更
- 不要になった `addScheduledMessageJob` / `removeScheduledMessageJob` を削除

## How

依存方向: `application/usecases → application/ports ← interfaces/cron` に修正。
composition root（main.ts / main.local.ts）で `scheduledMessageCronManager` を `cronSchedulerPort` として注入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/its-discord/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
