### PR TITLE
feat: doorコマンドを追加（PR #186 リファクタリング）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,6 @@ AUTH_REDIRECT_URL=
 
 DISCORD_LOG_WEBHOOK_URL=
 DATABASE_URL=
+
+# 開室状況 WebSocket URL（省略時: wss://its-status.woody1227.com/）
+# DOOR_STATUS_WS_URL=

--- a/src/interfaces/discordjs/commands/implementations/door.ts
+++ b/src/interfaces/discordjs/commands/implementations/door.ts
@@ -1,0 +1,77 @@
+import type { AppDeps } from "@application/ports";
+import type Command from "@domain/types/command";
+import {
+  type ChatInputCommandInteraction,
+  SlashCommandBuilder,
+} from "discord.js";
+
+const DOOR_STATUS_WS_URL =
+  process.env.DOOR_STATUS_WS_URL ?? "wss://its-status.woody1227.com/";
+const WS_TIMEOUT_MS = 8000;
+
+interface DoorStatus {
+  open?: boolean;
+  isOpen?: boolean;
+  status?: string;
+  message?: string;
+}
+
+function interpretStatus(data: string): string {
+  try {
+    const parsed: DoorStatus = JSON.parse(data);
+    const isOpen = parsed.open ?? parsed.isOpen ?? parsed.status === "open";
+
+    if (parsed.message) return parsed.message;
+    return isOpen ? "🟢 開室中" : "🔴 閉室中";
+  } catch {
+    return data || "⚪ 不明";
+  }
+}
+
+function fetchDoorStatus(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(DOOR_STATUS_WS_URL);
+
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error("WebSocket timeout"));
+    }, WS_TIMEOUT_MS);
+
+    ws.addEventListener("message", (event) => {
+      clearTimeout(timeout);
+      const raw =
+        typeof event.data === "string" ? event.data : String(event.data);
+      resolve(interpretStatus(raw));
+      ws.close();
+    });
+
+    ws.addEventListener("error", () => {
+      clearTimeout(timeout);
+      reject(new Error("WebSocket error"));
+    });
+  });
+}
+
+const doorCommand: Command = {
+  data: new SlashCommandBuilder()
+    .setName("door")
+    .setDescription("ITSの開室状況を表示します") as SlashCommandBuilder,
+  execute: doorCommandHandler,
+  isDMAllowed: true,
+};
+
+async function doorCommandHandler(
+  interaction: ChatInputCommandInteraction,
+  _deps: AppDeps,
+) {
+  await interaction.deferReply({ ephemeral: true });
+
+  try {
+    const status = await fetchDoorStatus();
+    await interaction.editReply(`現在の開室状況: ${status}`);
+  } catch {
+    await interaction.editReply("現在の開室状況: ❌ 通信に失敗しました");
+  }
+}
+
+export default doorCommand;

--- a/src/interfaces/discordjs/commands/index.ts
+++ b/src/interfaces/discordjs/commands/index.ts
@@ -1,5 +1,6 @@
 import CommandRegistry from "./core/commandRegistry";
 import auth from "./implementations/auth";
+import door from "./implementations/door";
 import healthCheck from "./implementations/healthCheck";
 import hotChannels from "./implementations/hotChannels";
 import kill from "./implementations/kill";
@@ -13,6 +14,7 @@ import who from "./implementations/who";
 const registry = new CommandRegistry();
 
 registry.register(auth);
+registry.register(door);
 registry.register(healthCheck);
 registry.register(hotChannels);
 registry.register(kill);


### PR DESCRIPTION
## Summary
- PR #186 の開室状況取得コマンドをリファクタリングして取り込み
- `ws` パッケージ依存を排除し、Node.js ネイティブ WebSocket を使用
- パスエイリアス・`Command` インターフェース準拠・URL 環境変数化

## Changes
- WebSocket URL を `DOOR_STATUS_WS_URL` 環境変数で設定可能に（デフォルト: `wss://its-status.woody1227.com/`）
- パース処理を `interpretStatus` に分離し可読性を改善
- 接続処理を `fetchDoorStatus` に分離し handler を簡潔化

## Original PR
Closes #186

## Test plan
- [ ] `deploy-commands:local` でコマンド登録を確認
- [ ] `/door` 実行で開室状況が表示されること
- [ ] WebSocket 接続不可時に「通信に失敗しました」が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)