### PR TITLE
refactor: doorコマンドの通信をアプリケーションポートに抽象化

### DIFF
--- a/src/application/ports/deps.ts
+++ b/src/application/ports/deps.ts
@@ -2,6 +2,7 @@ import type { DiscordChannelPort } from "./discordChannelPort";
 import type { DiscordGuildPort } from "./discordGuildPort";
 import type { DiscordMemberPort } from "./discordMemberPort";
 import type { DiscordMessagePort } from "./discordMessagePort";
+import type { DoorStatusPort } from "./doorStatusPort";
 import type { EmailAuthPort } from "./emailAuthPort";
 import type { ITSCorePort } from "./itsCorePort";
 import type { ScheduledMessagePort } from "./scheduledMessagePort";
@@ -18,4 +19,5 @@ export interface AppDeps {
   discordGuildPort: DiscordGuildPort;
   discordMessagePort: DiscordMessagePort;
   scheduledMessagePort: ScheduledMessagePort;
+  doorStatusPort: DoorStatusPort;
 }

--- a/src/application/ports/doorStatusPort.ts
+++ b/src/application/ports/doorStatusPort.ts
@@ -1,0 +1,12 @@
+export interface DoorStatus {
+  isOpen: boolean;
+  message?: string;
+}
+
+/**
+ * 開室状況を取得するPort
+ * 具体的な通信方式（WebSocket, HTTP等）は Infrastructure 層が決定する
+ */
+export interface DoorStatusPort {
+  fetchStatus(): Promise<DoorStatus>;
+}

--- a/src/application/ports/index.ts
+++ b/src/application/ports/index.ts
@@ -3,6 +3,7 @@ export type { DiscordChannel, DiscordChannelPort } from "./discordChannelPort";
 export type { DiscordGuildPort } from "./discordGuildPort";
 export type { DiscordMember, DiscordMemberPort } from "./discordMemberPort";
 export type { DiscordMessagePort } from "./discordMessagePort";
+export type { DoorStatus, DoorStatusPort } from "./doorStatusPort";
 export type {
   AuthUser,
   EmailAuthCredentials,

--- a/src/infrastructure/door-status/index.ts
+++ b/src/infrastructure/door-status/index.ts
@@ -1,0 +1,1 @@
+export { WebSocketDoorStatusAdapter } from "./webSocketDoorStatusAdapter";

--- a/src/infrastructure/door-status/webSocketDoorStatusAdapter.ts
+++ b/src/infrastructure/door-status/webSocketDoorStatusAdapter.ts
@@ -1,0 +1,56 @@
+import type { DoorStatus, DoorStatusPort } from "@application/ports";
+
+const WS_TIMEOUT_MS = 8000;
+
+interface RawDoorMessage {
+  open?: boolean;
+  isOpen?: boolean;
+  status?: string;
+  message?: string;
+}
+
+function parseMessage(data: string): DoorStatus {
+  const parsed: RawDoorMessage = JSON.parse(data);
+  const isOpen = parsed.open ?? parsed.isOpen ?? parsed.status === "open";
+
+  return {
+    isOpen,
+    message: parsed.message,
+  };
+}
+
+/**
+ * WebSocket 経由で開室状況を取得するアダプタ
+ */
+export class WebSocketDoorStatusAdapter implements DoorStatusPort {
+  constructor(private readonly url: string) {}
+
+  fetchStatus(): Promise<DoorStatus> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.url);
+
+      const timeout = setTimeout(() => {
+        ws.close();
+        reject(new Error("Door status WebSocket timeout"));
+      }, WS_TIMEOUT_MS);
+
+      ws.addEventListener("message", (event) => {
+        clearTimeout(timeout);
+        try {
+          const raw =
+            typeof event.data === "string" ? event.data : String(event.data);
+          resolve(parseMessage(raw));
+        } catch {
+          reject(new Error("Door status response parse error"));
+        } finally {
+          ws.close();
+        }
+      });
+
+      ws.addEventListener("error", () => {
+        clearTimeout(timeout);
+        reject(new Error("Door status WebSocket error"));
+      });
+    });
+  }
+}

--- a/src/interfaces/discordjs/commands/implementations/door.ts
+++ b/src/interfaces/discordjs/commands/implementations/door.ts
@@ -5,53 +5,6 @@ import {
   SlashCommandBuilder,
 } from "discord.js";
 
-const DOOR_STATUS_WS_URL =
-  process.env.DOOR_STATUS_WS_URL ?? "wss://its-status.woody1227.com/";
-const WS_TIMEOUT_MS = 8000;
-
-interface DoorStatus {
-  open?: boolean;
-  isOpen?: boolean;
-  status?: string;
-  message?: string;
-}
-
-function interpretStatus(data: string): string {
-  try {
-    const parsed: DoorStatus = JSON.parse(data);
-    const isOpen = parsed.open ?? parsed.isOpen ?? parsed.status === "open";
-
-    if (parsed.message) return parsed.message;
-    return isOpen ? "🟢 開室中" : "🔴 閉室中";
-  } catch {
-    return data || "⚪ 不明";
-  }
-}
-
-function fetchDoorStatus(): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const ws = new WebSocket(DOOR_STATUS_WS_URL);
-
-    const timeout = setTimeout(() => {
-      ws.close();
-      reject(new Error("WebSocket timeout"));
-    }, WS_TIMEOUT_MS);
-
-    ws.addEventListener("message", (event) => {
-      clearTimeout(timeout);
-      const raw =
-        typeof event.data === "string" ? event.data : String(event.data);
-      resolve(interpretStatus(raw));
-      ws.close();
-    });
-
-    ws.addEventListener("error", () => {
-      clearTimeout(timeout);
-      reject(new Error("WebSocket error"));
-    });
-  });
-}
-
 const doorCommand: Command = {
   data: new SlashCommandBuilder()
     .setName("door")
@@ -62,13 +15,14 @@ const doorCommand: Command = {
 
 async function doorCommandHandler(
   interaction: ChatInputCommandInteraction,
-  _deps: AppDeps,
+  deps: AppDeps,
 ) {
   await interaction.deferReply({ ephemeral: true });
 
   try {
-    const status = await fetchDoorStatus();
-    await interaction.editReply(`現在の開室状況: ${status}`);
+    const status = await deps.doorStatusPort.fetchStatus();
+    const text = status.message ?? (status.isOpen ? "🟢 開室中" : "🔴 閉室中");
+    await interaction.editReply(`現在の開室状況: ${text}`);
   } catch {
     await interaction.editReply("現在の開室状況: ❌ 通信に失敗しました");
   }

--- a/src/main.local.ts
+++ b/src/main.local.ts
@@ -8,6 +8,7 @@ import type { AdapterConfig } from "@config/environment";
 import { loadConfig } from "@config/environment";
 import { CustomClient } from "@domain/types";
 import { DiscordServerAdapter } from "@infrastructure/discordjs";
+import { WebSocketDoorStatusAdapter } from "@infrastructure/door-status";
 import { FirebaseEmailAuthAdapter } from "@infrastructure/firebase";
 import {
   InMemoryEmailAuthAdapter,
@@ -65,6 +66,8 @@ async function main() {
 
     // Composition Root: adapter を生成し依存オブジェクトを組み立てる
     const discordServerAdapter = new DiscordServerAdapter(client);
+    const doorStatusUrl =
+      process.env.DOOR_STATUS_WS_URL ?? "wss://its-status.woody1227.com/";
     const deps: AppDeps = {
       itsCorePort: createITSCorePort(config.adapters.itsCore),
       emailAuthPort: createEmailAuthPort(config.adapters.emailAuth),
@@ -73,6 +76,7 @@ async function main() {
       discordGuildPort: discordServerAdapter,
       discordMessagePort: discordServerAdapter,
       scheduledMessagePort: memoryScheduledMessageRepository,
+      doorStatusPort: new WebSocketDoorStatusAdapter(doorStatusUrl),
     };
 
     scheduledMessageCronManager.setDeps(deps);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { initializeScheduledMessagesFromConfig } from "@application/usecases";
 import { loadConfig } from "@config/environment";
 import { CustomClient } from "@domain/types";
 import { DiscordServerAdapter } from "@infrastructure/discordjs";
+import { WebSocketDoorStatusAdapter } from "@infrastructure/door-status";
 import { FirebaseEmailAuthAdapter } from "@infrastructure/firebase";
 import { ITSCoreAdaptor } from "@infrastructure/itscore";
 import logger from "@infrastructure/logger";
@@ -36,6 +37,8 @@ async function main() {
 
     // Composition Root: adapter を生成し依存オブジェクトを組み立てる
     const discordServerAdapter = new DiscordServerAdapter(client);
+    const doorStatusUrl =
+      process.env.DOOR_STATUS_WS_URL ?? "wss://its-status.woody1227.com/";
     const deps: AppDeps = {
       itsCorePort: new ITSCoreAdaptor(),
       emailAuthPort: new FirebaseEmailAuthAdapter(),
@@ -44,6 +47,7 @@ async function main() {
       discordGuildPort: discordServerAdapter,
       discordMessagePort: discordServerAdapter,
       scheduledMessagePort: memoryScheduledMessageRepository,
+      doorStatusPort: new WebSocketDoorStatusAdapter(doorStatusUrl),
     };
 
     // Cron manager に依存オブジェクトを設定


### PR DESCRIPTION
## Summary
- `DoorStatusPort` をアプリケーションポートとして定義
- WebSocket接続の詳細を `WebSocketDoorStatusAdapter`（インフラ層）に隠蔽
- コマンドハンドラは `deps.doorStatusPort.fetchStatus()` のみに依存

## Why
特定のWebSocketサーバー実装への依存をインフラストラクチャ層に閉じ込め、
通信方式やサーバーの変更がアダプタ差し替えだけで完結するようにする。

## What
```
src/application/ports/doorStatusPort.ts  -- ポート定義
src/infrastructure/door-status/          -- WebSocketアダプタ
src/interfaces/.../door.ts               -- ハンドラ簡素化
src/main.ts, src/main.local.ts           -- DI登録
```

## Test plan
- [ ] `tsc --noEmit` パス確認済
- [ ] `biome check` パス確認済
- [ ] `/door` 実行で開室状況が表示されること
- [ ] WebSocket 接続不可時にエラーメッセージが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)