### PR TITLE
feat: 開室状況を表示する door コマンドを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,5 +26,5 @@ AUTH_REDIRECT_URL=
 DISCORD_LOG_WEBHOOK_URL=
 DATABASE_URL=
 
-# 開室状況 WebSocket URL（省略時: wss://its-status.woody1227.com/）
+# 開室状況 WebSocket URL（省略時: wss://its-status-ws.woody1227.com/）
 # DOOR_STATUS_WS_URL=

--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,6 @@ AUTH_REDIRECT_URL=
 
 DISCORD_LOG_WEBHOOK_URL=
 DATABASE_URL=
+
+# 開室状況 WebSocket URL（省略時: wss://its-status.woody1227.com/）
+# DOOR_STATUS_WS_URL=

--- a/src/application/ports/deps.ts
+++ b/src/application/ports/deps.ts
@@ -2,6 +2,7 @@ import type { DiscordChannelPort } from "./discordChannelPort";
 import type { DiscordGuildPort } from "./discordGuildPort";
 import type { DiscordMemberPort } from "./discordMemberPort";
 import type { DiscordMessagePort } from "./discordMessagePort";
+import type { DoorStatusPort } from "./doorStatusPort";
 import type { EmailAuthPort } from "./emailAuthPort";
 import type { ITSCorePort } from "./itsCorePort";
 import type { ScheduledMessagePort } from "./scheduledMessagePort";
@@ -18,4 +19,5 @@ export interface AppDeps {
   discordGuildPort: DiscordGuildPort;
   discordMessagePort: DiscordMessagePort;
   scheduledMessagePort: ScheduledMessagePort;
+  doorStatusPort: DoorStatusPort;
 }

--- a/src/application/ports/doorStatusPort.ts
+++ b/src/application/ports/doorStatusPort.ts
@@ -1,0 +1,12 @@
+export interface DoorStatus {
+  isOpen: boolean;
+  message?: string;
+}
+
+/**
+ * 開室状況を取得するPort
+ * 具体的な通信方式（WebSocket, HTTP等）は Infrastructure 層が決定する
+ */
+export interface DoorStatusPort {
+  fetchStatus(): Promise<DoorStatus>;
+}

--- a/src/application/ports/doorStatusPort.ts
+++ b/src/application/ports/doorStatusPort.ts
@@ -1,12 +1,10 @@
 export interface DoorStatus {
   isOpen: boolean;
-  message?: string;
 }
 
 /**
  * 開室状況を取得するPort
- * 具体的な通信方式（WebSocket, HTTP等）は Infrastructure 層が決定する
  */
 export interface DoorStatusPort {
-  fetchStatus(): Promise<DoorStatus>;
+  getStatus(): Promise<DoorStatus>;
 }

--- a/src/application/ports/index.ts
+++ b/src/application/ports/index.ts
@@ -3,6 +3,7 @@ export type { DiscordChannel, DiscordChannelPort } from "./discordChannelPort";
 export type { DiscordGuildPort } from "./discordGuildPort";
 export type { DiscordMember, DiscordMemberPort } from "./discordMemberPort";
 export type { DiscordMessagePort } from "./discordMessagePort";
+export type { DoorStatus, DoorStatusPort } from "./doorStatusPort";
 export type {
   AuthUser,
   EmailAuthCredentials,

--- a/src/infrastructure/door-status/index.ts
+++ b/src/infrastructure/door-status/index.ts
@@ -1,0 +1,1 @@
+export { WebSocketDoorStatusAdapter } from "./webSocketDoorStatusAdapter";

--- a/src/infrastructure/door-status/index.ts
+++ b/src/infrastructure/door-status/index.ts
@@ -1,1 +1,1 @@
-export { WebSocketDoorStatusAdapter } from "./webSocketDoorStatusAdapter";
+export { WoodyDoorStatusAdapter } from "./woodyDoorStatusAdapter";

--- a/src/infrastructure/door-status/webSocketDoorStatusAdapter.ts
+++ b/src/infrastructure/door-status/webSocketDoorStatusAdapter.ts
@@ -1,0 +1,56 @@
+import type { DoorStatus, DoorStatusPort } from "@application/ports";
+
+const WS_TIMEOUT_MS = 8000;
+
+interface RawDoorMessage {
+  open?: boolean;
+  isOpen?: boolean;
+  status?: string;
+  message?: string;
+}
+
+function parseMessage(data: string): DoorStatus {
+  const parsed: RawDoorMessage = JSON.parse(data);
+  const isOpen = parsed.open ?? parsed.isOpen ?? parsed.status === "open";
+
+  return {
+    isOpen,
+    message: parsed.message,
+  };
+}
+
+/**
+ * WebSocket 経由で開室状況を取得するアダプタ
+ */
+export class WebSocketDoorStatusAdapter implements DoorStatusPort {
+  constructor(private readonly url: string) {}
+
+  fetchStatus(): Promise<DoorStatus> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.url);
+
+      const timeout = setTimeout(() => {
+        ws.close();
+        reject(new Error("Door status WebSocket timeout"));
+      }, WS_TIMEOUT_MS);
+
+      ws.addEventListener("message", (event) => {
+        clearTimeout(timeout);
+        try {
+          const raw =
+            typeof event.data === "string" ? event.data : String(event.data);
+          resolve(parseMessage(raw));
+        } catch {
+          reject(new Error("Door status response parse error"));
+        } finally {
+          ws.close();
+        }
+      });
+
+      ws.addEventListener("error", () => {
+        clearTimeout(timeout);
+        reject(new Error("Door status WebSocket error"));
+      });
+    });
+  }
+}

--- a/src/infrastructure/door-status/woodyDoorStatusAdapter.ts
+++ b/src/infrastructure/door-status/woodyDoorStatusAdapter.ts
@@ -2,30 +2,25 @@ import type { DoorStatus, DoorStatusPort } from "@application/ports";
 
 const WS_TIMEOUT_MS = 8000;
 
-interface RawDoorMessage {
+interface WoodyStatusMessage {
   open?: boolean;
   isOpen?: boolean;
   status?: string;
-  message?: string;
 }
 
 function parseMessage(data: string): DoorStatus {
-  const parsed: RawDoorMessage = JSON.parse(data);
+  const parsed: WoodyStatusMessage = JSON.parse(data);
   const isOpen = parsed.open ?? parsed.isOpen ?? parsed.status === "open";
-
-  return {
-    isOpen,
-    message: parsed.message,
-  };
+  return { isOpen };
 }
 
 /**
- * WebSocket 経由で開室状況を取得するアダプタ
+ * Woody さんの its-status サーバーから開室状況を取得するアダプタ
  */
-export class WebSocketDoorStatusAdapter implements DoorStatusPort {
+export class WoodyDoorStatusAdapter implements DoorStatusPort {
   constructor(private readonly url: string) {}
 
-  fetchStatus(): Promise<DoorStatus> {
+  getStatus(): Promise<DoorStatus> {
     return new Promise((resolve, reject) => {
       const ws = new WebSocket(this.url);
 

--- a/src/infrastructure/door-status/woodyDoorStatusAdapter.ts
+++ b/src/infrastructure/door-status/woodyDoorStatusAdapter.ts
@@ -3,15 +3,14 @@ import type { DoorStatus, DoorStatusPort } from "@application/ports";
 const WS_TIMEOUT_MS = 8000;
 
 interface WoodyStatusMessage {
-  open?: boolean;
-  isOpen?: boolean;
-  status?: string;
+  state: "open" | "closed";
+  battery: number;
+  updated_at: string;
 }
 
 function parseMessage(data: string): DoorStatus {
   const parsed: WoodyStatusMessage = JSON.parse(data);
-  const isOpen = parsed.open ?? parsed.isOpen ?? parsed.status === "open";
-  return { isOpen };
+  return { isOpen: parsed.state === "open" };
 }
 
 /**

--- a/src/interfaces/discordjs/commands/implementations/door.ts
+++ b/src/interfaces/discordjs/commands/implementations/door.ts
@@ -20,8 +20,8 @@ async function doorCommandHandler(
   await interaction.deferReply({ ephemeral: true });
 
   try {
-    const status = await deps.doorStatusPort.fetchStatus();
-    const text = status.message ?? (status.isOpen ? "🟢 開室中" : "🔴 閉室中");
+    const status = await deps.doorStatusPort.getStatus();
+    const text = status.isOpen ? "🟢 開室中" : "🔴 閉室中";
     await interaction.editReply(`現在の開室状況: ${text}`);
   } catch {
     await interaction.editReply("現在の開室状況: ❌ 通信に失敗しました");

--- a/src/interfaces/discordjs/commands/implementations/door.ts
+++ b/src/interfaces/discordjs/commands/implementations/door.ts
@@ -1,0 +1,31 @@
+import type { AppDeps } from "@application/ports";
+import type Command from "@domain/types/command";
+import {
+  type ChatInputCommandInteraction,
+  SlashCommandBuilder,
+} from "discord.js";
+
+const doorCommand: Command = {
+  data: new SlashCommandBuilder()
+    .setName("door")
+    .setDescription("ITSの開室状況を表示します") as SlashCommandBuilder,
+  execute: doorCommandHandler,
+  isDMAllowed: true,
+};
+
+async function doorCommandHandler(
+  interaction: ChatInputCommandInteraction,
+  deps: AppDeps,
+) {
+  await interaction.deferReply({ ephemeral: true });
+
+  try {
+    const status = await deps.doorStatusPort.fetchStatus();
+    const text = status.message ?? (status.isOpen ? "🟢 開室中" : "🔴 閉室中");
+    await interaction.editReply(`現在の開室状況: ${text}`);
+  } catch {
+    await interaction.editReply("現在の開室状況: ❌ 通信に失敗しました");
+  }
+}
+
+export default doorCommand;

--- a/src/interfaces/discordjs/commands/index.ts
+++ b/src/interfaces/discordjs/commands/index.ts
@@ -1,5 +1,6 @@
 import CommandRegistry from "./core/commandRegistry";
 import auth from "./implementations/auth";
+import door from "./implementations/door";
 import healthCheck from "./implementations/healthCheck";
 import hotChannels from "./implementations/hotChannels";
 import kill from "./implementations/kill";
@@ -13,6 +14,7 @@ import who from "./implementations/who";
 const registry = new CommandRegistry();
 
 registry.register(auth);
+registry.register(door);
 registry.register(healthCheck);
 registry.register(hotChannels);
 registry.register(kill);

--- a/src/main.local.ts
+++ b/src/main.local.ts
@@ -8,7 +8,7 @@ import type { AdapterConfig } from "@config/environment";
 import { loadConfig } from "@config/environment";
 import { CustomClient } from "@domain/types";
 import { DiscordServerAdapter } from "@infrastructure/discordjs";
-import { WebSocketDoorStatusAdapter } from "@infrastructure/door-status";
+import { WoodyDoorStatusAdapter } from "@infrastructure/door-status";
 import { FirebaseEmailAuthAdapter } from "@infrastructure/firebase";
 import {
   InMemoryEmailAuthAdapter,
@@ -76,7 +76,7 @@ async function main() {
       discordGuildPort: discordServerAdapter,
       discordMessagePort: discordServerAdapter,
       scheduledMessagePort: memoryScheduledMessageRepository,
-      doorStatusPort: new WebSocketDoorStatusAdapter(doorStatusUrl),
+      doorStatusPort: new WoodyDoorStatusAdapter(doorStatusUrl),
     };
 
     scheduledMessageCronManager.setDeps(deps);

--- a/src/main.local.ts
+++ b/src/main.local.ts
@@ -67,7 +67,7 @@ async function main() {
     // Composition Root: adapter を生成し依存オブジェクトを組み立てる
     const discordServerAdapter = new DiscordServerAdapter(client);
     const doorStatusUrl =
-      process.env.DOOR_STATUS_WS_URL ?? "wss://its-status.woody1227.com/";
+      process.env.DOOR_STATUS_WS_URL ?? "wss://its-status-ws.woody1227.com/";
     const deps: AppDeps = {
       itsCorePort: createITSCorePort(config.adapters.itsCore),
       emailAuthPort: createEmailAuthPort(config.adapters.emailAuth),

--- a/src/main.local.ts
+++ b/src/main.local.ts
@@ -8,6 +8,7 @@ import type { AdapterConfig } from "@config/environment";
 import { loadConfig } from "@config/environment";
 import { CustomClient } from "@domain/types";
 import { DiscordServerAdapter } from "@infrastructure/discordjs";
+import { WebSocketDoorStatusAdapter } from "@infrastructure/door-status";
 import { FirebaseEmailAuthAdapter } from "@infrastructure/firebase";
 import {
   InMemoryEmailAuthAdapter,
@@ -65,6 +66,8 @@ async function main() {
 
     // Composition Root: adapter を生成し依存オブジェクトを組み立てる
     const discordServerAdapter = new DiscordServerAdapter(client);
+    const doorStatusUrl =
+      process.env.DOOR_STATUS_WS_URL ?? "wss://its-status.woody1227.com/";
     const deps: AppDeps = {
       itsCorePort: createITSCorePort(config.adapters.itsCore),
       emailAuthPort: createEmailAuthPort(config.adapters.emailAuth),
@@ -73,6 +76,7 @@ async function main() {
       discordGuildPort: discordServerAdapter,
       discordMessagePort: discordServerAdapter,
       scheduledMessagePort: memoryScheduledMessageRepository,
+      doorStatusPort: new WebSocketDoorStatusAdapter(doorStatusUrl),
     };
 
     scheduledMessageCronManager.setDeps(deps);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { initializeScheduledMessagesFromConfig } from "@application/usecases";
 import { loadConfig } from "@config/environment";
 import { CustomClient } from "@domain/types";
 import { DiscordServerAdapter } from "@infrastructure/discordjs";
-import { WebSocketDoorStatusAdapter } from "@infrastructure/door-status";
+import { WoodyDoorStatusAdapter } from "@infrastructure/door-status";
 import { FirebaseEmailAuthAdapter } from "@infrastructure/firebase";
 import { ITSCoreAdaptor } from "@infrastructure/itscore";
 import logger from "@infrastructure/logger";
@@ -47,7 +47,7 @@ async function main() {
       discordGuildPort: discordServerAdapter,
       discordMessagePort: discordServerAdapter,
       scheduledMessagePort: memoryScheduledMessageRepository,
-      doorStatusPort: new WebSocketDoorStatusAdapter(doorStatusUrl),
+      doorStatusPort: new WoodyDoorStatusAdapter(doorStatusUrl),
     };
 
     // Cron manager に依存オブジェクトを設定

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { initializeScheduledMessagesFromConfig } from "@application/usecases";
 import { loadConfig } from "@config/environment";
 import { CustomClient } from "@domain/types";
 import { DiscordServerAdapter } from "@infrastructure/discordjs";
+import { WebSocketDoorStatusAdapter } from "@infrastructure/door-status";
 import { FirebaseEmailAuthAdapter } from "@infrastructure/firebase";
 import { ITSCoreAdaptor } from "@infrastructure/itscore";
 import logger from "@infrastructure/logger";
@@ -36,6 +37,8 @@ async function main() {
 
     // Composition Root: adapter を生成し依存オブジェクトを組み立てる
     const discordServerAdapter = new DiscordServerAdapter(client);
+    const doorStatusUrl =
+      process.env.DOOR_STATUS_WS_URL ?? "wss://its-status.woody1227.com/";
     const deps: AppDeps = {
       itsCorePort: new ITSCoreAdaptor(),
       emailAuthPort: new FirebaseEmailAuthAdapter(),
@@ -44,6 +47,7 @@ async function main() {
       discordGuildPort: discordServerAdapter,
       discordMessagePort: discordServerAdapter,
       scheduledMessagePort: memoryScheduledMessageRepository,
+      doorStatusPort: new WebSocketDoorStatusAdapter(doorStatusUrl),
     };
 
     // Cron manager に依存オブジェクトを設定

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ async function main() {
     // Composition Root: adapter を生成し依存オブジェクトを組み立てる
     const discordServerAdapter = new DiscordServerAdapter(client);
     const doorStatusUrl =
-      process.env.DOOR_STATUS_WS_URL ?? "wss://its-status.woody1227.com/";
+      process.env.DOOR_STATUS_WS_URL ?? "wss://its-status-ws.woody1227.com/";
     const deps: AppDeps = {
       itsCorePort: new ITSCoreAdaptor(),
       emailAuthPort: new FirebaseEmailAuthAdapter(),


### PR DESCRIPTION
## Summary
- PR #186 (by @woody-1227) の開室状況取得コマンドをリファクタリングして取り込み
- `DoorStatusPort` をアプリケーションポートとして定義し、WebSocket 接続の詳細をインフラ層に隠蔽
- Node.js ネイティブ WebSocket を使用（`ws` パッケージ不要）

## Why
特定の外部 WebSocket サーバーへの依存をインフラストラクチャ層に閉じ込め、
通信方式やサーバーの変更がアダプタ差し替えで完結するようにする。

## What
```
src/application/ports/doorStatusPort.ts           -- ポート定義（DoorStatus, DoorStatusPort）
src/application/ports/deps.ts                     -- AppDeps に doorStatusPort 追加
src/infrastructure/door-status/                   -- WebSocketDoorStatusAdapter
src/interfaces/.../implementations/door.ts        -- コマンドハンドラ（deps 経由で取得）
src/main.ts, src/main.local.ts                    -- Composition Root に DI 登録
.env.example                                      -- DOOR_STATUS_WS_URL 追加
```

## Original work
Based on #186 by @woody-1227

## Test plan
- [ ] `tsc --noEmit` パス確認済
- [ ] `biome check` パス確認済
- [ ] `/door` 実行で開室状況が表示されること
- [ ] WebSocket 接続不可時にエラーメッセージが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)