### PR TITLE
fix: door コマンドが開室時も閉室と判定するバグを修正

### DIFF
--- a/src/infrastructure/door-status/woodyDoorStatusAdapter.ts
+++ b/src/infrastructure/door-status/woodyDoorStatusAdapter.ts
@@ -3,14 +3,14 @@ import type { DoorStatus, DoorStatusPort } from "@application/ports";
 const WS_TIMEOUT_MS = 8000;
 
 interface WoodyStatusMessage {
-  state: "open" | "closed";
+  state: "opened" | "closed";
   battery: number;
   updated_at: string;
 }
 
 function parseMessage(data: string): DoorStatus {
   const parsed: WoodyStatusMessage = JSON.parse(data);
-  return { isOpen: parsed.state === "open" };
+  return { isOpen: parsed.state === "opened" };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Woody サーバーは開室時に `"open"` ではなく `"opened"` を返す
- `parsed.state === "open"` が常に false になり、開室中でも 🔴 閉室中 と表示されていた

## Test plan
- [x] WSサーバーから `{"state": "opened", ...}` が返ることを確認済み
- [ ] `/door` で開室時に 🟢 開室中 が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)